### PR TITLE
Make the systemd dependency optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,10 @@ version = "1.3"
 default-features = false
 features = ["precommit-hook", "run-cargo-test", "run-cargo-clippy"]
 
+[features]
+default = ["journald-source"]
+journald-source = ["systemd"]
+
 [dependencies]
 clap = { version = "2.32", features = ["yaml"] }
 failure = "0.1"
@@ -42,7 +46,7 @@ futures = "0.1"
 tokio = "0.1"
 notify = "4.0"
 walkdir = "2.2"
-systemd = "0.4"
+systemd = {version = "0.4", optional = true }
 reqwest = "0.9"
 url = "1.7"
 log = { version = "0.4", features = ["std"] }

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -2,8 +2,13 @@ use failure::Error;
 use futures::Stream;
 
 mod fs;
+#[cfg(feature = "journald-source")]
 mod journald;
-pub use self::{fs::FsLogSource, journald::JournaldLogSource};
+
+pub use self::fs::FsLogSource;
+
+#[cfg(feature = "journald-source")]
+pub use self::journald::JournaldLogSource;
 
 #[derive(Debug, PartialEq)]
 pub struct LogRecord {


### PR DESCRIPTION
Hides it under the journald-source feature,
which is default on.

It is useful when using as a library with the log crate.