### PR TITLE
Make TelegramLogger struct public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ fn format_message(record: &Record) -> String {
     text
 }
 
-struct TelegramLogger {
+pub struct TelegramLogger {
     level: Level,
     token: String,
     chat_id: String,


### PR DESCRIPTION
Now I can init the logger on my own, or pass it as an argument to an other "composite" logger.
Look at multi_log crate to see usage.